### PR TITLE
replace variable parentheses in flask routes

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -8,6 +8,7 @@ we add the endpoint to swagger specification output
 """
 import inspect
 import yaml
+import re
 
 
 def _sanitize(comment):
@@ -111,5 +112,8 @@ def swagger(app):
                     parameters=params
                 )
         if len(operations):
-            paths[str(rule)] = operations
+            rule = str(rule)
+            for arg in re.findall('(<(.*?\:)?(.*?)>)', rule):
+                rule = rule.replace(arg[0], '{%s}' % arg[2])
+            paths[rule] = operations
     return output


### PR DESCRIPTION
Currently, flask-swagger uses literal Flask route names as path names in the swagger spec. This causes problems when the route contains variables, because Flask uses angle brackets to mark variables (e.g., `<id>`), whereas the swagger spec expects curly brackets to mark replaceable elements (e.g., {id}). As a result of the discrepancy, swagger-ui doesn't retrieve data properly when testing out paths.

This PR ensures that any variables in Flask routes are handled appropriately. It replaces angle brackets with curly braces, and also handles cases where the Flask route includes a data type specification (e.g., `<string:name>` becomes {name}).
