### PR TITLE
Handling multiple views for same route

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -125,5 +125,8 @@ def swagger(app):
             rule = str(rule)
             for arg in re.findall('(<(.*?\:)?(.*?)>)', rule):
                 rule = rule.replace(arg[0], '{%s}' % arg[2])
-            paths[rule] = operations
+            if rule in paths:
+                paths[rule].update(operations)
+            else:
+                paths[rule] = operations
     return output


### PR DESCRIPTION
If you have two separate view functions handling different http verbs, currently only one of them appears in the swagger output since the latter one overwrites the earlier. This is a fix for that.
