### PR TITLE
Add ability to define definitions within other definitions

### DIFF
--- a/README
+++ b/README
@@ -39,6 +39,19 @@ objects.
                     name:
                       type: string
                       description: name for user
+                    address:
+                      description: address for user
+                      schema:
+                        id: Address
+                        properties:
+                          street:
+                            type: string
+                          state:
+                            type: string
+                          country:
+                            type: string
+                          postalcode:
+                            type: string
             responses:
               201:
                 description: User created
@@ -68,6 +81,11 @@ place the
 object in the
 `Definitions <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject>`__
 object.
+
+`Schema <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject>`__
+objects can also be defined within the properties of other __
+`Schema <https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject>`__
+objects. An example is shown above with the address property of User.
 
 To expose your Swagger specification to the world you provide a Flask
 route that does something along these lines

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ class UserAPI(MethodView):
                 name:
                   type: string
                   description: name for user
+                address:
+                  description: address for user
+                  schema:
+                    id: Address
+                    properties:
+                      street:
+                        type: string
+                      state:
+                        type: string
+                      country:
+                        type: string
+                      postalcode:
+                        type: string
         responses:
           201:
             description: User created
@@ -42,6 +55,8 @@ Flask-swagger supports docstrings in methods of MethodView classes and regular F
 Following YAML conventions, flask-swagger searches for `---`, everything preceding is provided as `summary` (first line) and `description` (following lines) for the endpoint while everything after is parsed as a swagger [Operation](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operation-object) object.
 
 In order to support inline definition of [Schema ](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) objects in [Parameter](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameterObject)  and [Response](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responsesObject) objects, flask-swagger veers a little off from the standard. We require an `id` field for the inline Schema which is then used to correctly place the [Schema](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) object in the [Definitions](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject) object.
+
+[Schema ](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) objects can also be defined within the properties of other [Schema ](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) objects . An example is shown above with the address property of User.
 
 To expose your Swagger specification to the world you provide a Flask route that does something along these lines
 

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -10,6 +10,7 @@ import inspect
 import yaml
 import re
 
+from collections import defaultdict
 
 def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
@@ -73,8 +74,8 @@ def swagger(app):
             "version": "0.0.0",
             "title": "Cool product name",
         },
-        "paths": dict(),
-        "definitions": dict()
+        "paths": defaultdict(dict),
+        "definitions": defaultdict(dict)
     }
 
     paths = output['paths']
@@ -106,7 +107,7 @@ def swagger(app):
                 for definition in defs:
                     def_id = definition.get('id')
                     if def_id is not None:
-                        definitions[def_id] = definition
+                        definitions[def_id].update(definition)
                 operation = dict(
                     summary=summary,
                     description=description,
@@ -125,8 +126,5 @@ def swagger(app):
             rule = str(rule)
             for arg in re.findall('(<(.*?\:)?(.*?)>)', rule):
                 rule = rule.replace(arg[0], '{%s}' % arg[2])
-            if rule in paths:
-                paths[rule].update(operations)
-            else:
-                paths[rule] = operations
+            paths[rule].update(operations)
     return output


### PR DESCRIPTION
Currently it is not possible to define definitions within the properties or items (if within an array) of other definitions. 

This change recursively traverses the properties of definitions to find other schema defs. This is a deviation from the standard, but the cleanest way I could think to handle it. 

Also builds on the work by abhaga to handle multiple views for same route. Handles the case where definitions get overridden by separate view functions for the same verb.
