### PR TITLE
Stringify `responses` to make validator happy

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -97,7 +97,7 @@ def swagger(app, process_doc=_sanitize):
     We go through all endpoints of the app searching for swagger endpoints
     We provide the minimum required data according to swagger specs
     Callers can and should add and override at will
-    
+
     Arguments:
     app -- the flask app to inspect
 
@@ -138,6 +138,10 @@ def swagger(app, process_doc=_sanitize):
                 params = swag.get('parameters', [])
                 defs = _extract_definitions(params)
                 responses = swag.get('responses', {})
+                responses = {
+                    str(key): value
+                    for key, value in responses.items()
+                }
                 if responses is not None:
                     defs = defs + _extract_definitions(responses.values())
                 for definition in defs:


### PR DESCRIPTION
If you will try to use jsonschema`s  Draft4Validator to
validate swagger.json, generated by flask-swagger, then
will discover it is failing, trying to match numerical
HTTP status codes from responses agains this piece
of Swagger 2.0 spec:

```
"responses": {
  "type": "object",
  "description": "Response objects names can either be any valid
  HTTP status code or 'default'.",
  "minProperties": 1,
  "additionalProperties": false,
  "patternProperties": {
    "^([0-9]{3})$|^(default)$": {
      "$ref": "#/definitions/responseValue"
    },
    "^x-": {
      "$ref": "#/definitions/vendorExtension"
    }
  }
}
```

This fix just coerse responses keys to strings.
