### PR TITLE
support factored out definitions

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -94,6 +94,50 @@ def bla():
     """
     return jsonify(['hacky'])
 
+class PetAPI(MethodView):
+
+    def get(self, pet_id):
+        """
+        Get a pet.
+
+        This is an example of how to use references and factored out definitions
+        ---
+        tags:
+          - pets
+        parameters:
+          - in: path
+            name: pet_id
+        definitions:
+          - schema:
+              id: Pet
+              required:
+                - name
+                - owner
+              properties:
+                name:
+                  type: string
+                  description: the pet's name
+                owner:
+                  $ref: '#/definitions/Owner'
+          - schema:
+              id: Owner
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: the owner's name
+        responses:
+          200:
+            description: Returns the specified pet
+            $ref: '#/definitions/Pet'
+        """
+        return {}
+
+pet_view = PetAPI.as_view('pets')
+app.add_url_rule('/pets/<int:pet_id>', view_func=pet_view, methods=["GET"])
+
+
 @app.route("/")
 def hello():
     return "Hello World!"

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -135,8 +135,10 @@ def swagger(app, process_doc=_sanitize):
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc)
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
+                defs = swag.get('definitions', [])
+                defs = _extract_definitions(defs)
                 params = swag.get('parameters', [])
-                defs = _extract_definitions(params)
+                defs += _extract_definitions(params)
                 responses = swag.get('responses', {})
                 responses = {
                     str(key): value


### PR DESCRIPTION
By adding support for a top-level "definitions:" item in
docstrings, we can factor out deep models and use
references. This helps keep nesting manageable.
