### PR TITLE
Added bdist_rpm support for building an RPM from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,25 @@ setup(name='flask-swagger',
       entry_points = """
       [console_scripts]
       flaskswagger = build_swagger_spec:run
-      """
+      """,
+      options={
+        'bdist_rpm':{
+          'build_requires':[
+            'python',
+            'python-setuptools',
+            'python-itsdangerous',
+            'python-flask',
+            'python-markupsafe',
+            'PyYAML',
+          ],
+          'requires':[
+            'python',
+            'python-setuptools',
+            'python-itsdangerous',
+            'python-flask',
+            'python-markupsafe',
+            'PyYAML',
+          ],
+        },
+      },
       )


### PR DESCRIPTION
Confirmation that this works from my desktop::

[krasmussen@kras-desktop flask-swagger]$ python ./setup.py bdist_rpm
running bdist_rpm
running egg_info
creating flask_swagger.egg-info
writing requirements to flask_swagger.egg-info/requires.txt
writing flask_swagger.egg-info/PKG-INFO
writing top-level names to flask_swagger.egg-info/top_level.txt
writing dependency_links to flask_swagger.egg-info/dependency_links.txt
writing entry points to flask_swagger.egg-info/entry_points.txt
writing pbr to flask_swagger.egg-info/pbr.json
writing manifest file 'flask_swagger.egg-info/SOURCES.txt'
reading manifest file 'flask_swagger.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'flask_swagger.egg-info/SOURCES.txt'
creating build
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/rpm
creating build/bdist.linux-x86_64/rpm/SOURCES
creating build/bdist.linux-x86_64/rpm/SPECS
creating build/bdist.linux-x86_64/rpm/BUILD
creating build/bdist.linux-x86_64/rpm/RPMS
creating build/bdist.linux-x86_64/rpm/SRPMS
writing 'build/bdist.linux-x86_64/rpm/SPECS/flask-swagger.spec'
running sdist
running check
warning: check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

creating flask-swagger-0.2.11
creating flask-swagger-0.2.11/flask_swagger.egg-info
making hard links in flask-swagger-0.2.11...
hard linking LICENSE -> flask-swagger-0.2.11
hard linking MANIFEST.in -> flask-swagger-0.2.11
hard linking README -> flask-swagger-0.2.11
hard linking README.md -> flask-swagger-0.2.11
hard linking build_swagger_spec.py -> flask-swagger-0.2.11
hard linking flask_swagger.py -> flask-swagger-0.2.11
hard linking setup.py -> flask-swagger-0.2.11
hard linking flask_swagger.egg-info/PKG-INFO -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/SOURCES.txt -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/dependency_links.txt -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/entry_points.txt -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/pbr.json -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/requires.txt -> flask-swagger-0.2.11/flask_swagger.egg-info
hard linking flask_swagger.egg-info/top_level.txt -> flask-swagger-0.2.11/flask_swagger.egg-info
Writing flask-swagger-0.2.11/setup.cfg
creating dist
Creating tar archive
removing 'flask-swagger-0.2.11' (and everything under it)
copying dist/flask-swagger-0.2.11.tar.gz -> build/bdist.linux-x86_64/rpm/SOURCES
building RPMs
rpmbuild -ba --define _topdir /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm --clean build/bdist.linux-x86_64/rpm/SPECS/flask-swagger.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.uDFSi3
- umask 022
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- rm -rf flask-swagger-0.2.11
- /usr/bin/tar -xvvf -
- /usr/bin/gzip -dc /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/SOURCES/flask-swagger-0.2.11.tar.gz
  drwxrwxr-x krasmussen/krasmussen 0 2015-11-10 14:03 flask-swagger-0.2.11/
  drwxrwxr-x krasmussen/krasmussen 0 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/
  -rw-rw-r-- krasmussen/krasmussen 6334 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/PKG-INFO
  -rw-rw-r-- krasmussen/krasmussen  340 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/SOURCES.txt
  -rw-rw-r-- krasmussen/krasmussen    1 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/dependency_links.txt
  -rw-rw-r-- krasmussen/krasmussen   75 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/entry_points.txt
  -rw-rw-r-- krasmussen/krasmussen   47 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/pbr.json
  -rw-rw-r-- krasmussen/krasmussen   24 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/requires.txt
  -rw-rw-r-- krasmussen/krasmussen   33 2015-11-10 14:03 flask-swagger-0.2.11/flask_swagger.egg-info/top_level.txt
  -rw-rw-r-- krasmussen/krasmussen 1085 2015-11-10 12:05 flask-swagger-0.2.11/LICENSE
  -rw-rw-r-- krasmussen/krasmussen   21 2015-11-10 12:05 flask-swagger-0.2.11/MANIFEST.in
  -rw-rw-r-- krasmussen/krasmussen 4938 2015-11-10 12:05 flask-swagger-0.2.11/README
  -rw-rw-r-- krasmussen/krasmussen 5662 2015-11-10 12:05 flask-swagger-0.2.11/README.md
  -rw-rw-r-- krasmussen/krasmussen  932 2015-11-10 12:05 flask-swagger-0.2.11/build_swagger_spec.py
  -rw-rw-r-- krasmussen/krasmussen 6685 2015-11-10 12:05 flask-swagger-0.2.11/flask_swagger.py
  -rw-rw-r-- krasmussen/krasmussen 1139 2015-11-10 14:02 flask-swagger-0.2.11/setup.py
  -rw-rw-r-- krasmussen/krasmussen 6334 2015-11-10 14:03 flask-swagger-0.2.11/PKG-INFO
  -rw-rw-r-- krasmussen/krasmussen   59 2015-11-10 14:03 flask-swagger-0.2.11/setup.cfg
- STATUS=0
- '[' 0 -ne 0 ']'
- cd flask-swagger-0.2.11
- /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
- exit 0
  Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.5JYtDg
- umask 022
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- cd flask-swagger-0.2.11
- python setup.py build
  running build
  running build_py
  creating build
  creating build/lib
  copying flask_swagger.py -> build/lib
  copying build_swagger_spec.py -> build/lib
- exit 0
  Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.9NTxOv
- umask 022
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- '[' /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64 '!=' / ']'
- rm -rf /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64
  ++ dirname /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64
- mkdir -p /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT
- mkdir /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64
- cd flask-swagger-0.2.11
- python setup.py install --single-version-externally-managed -O1 --root=/home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64 --record=INSTALLED_FILES
  running install
  running build
  running build_py
  running install_lib
  creating /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr
  creating /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib
  creating /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7
  creating /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages
  copying build/lib/flask_swagger.py -> /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages
  copying build/lib/build_swagger_spec.py -> /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages
  byte-compiling /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages/flask_swagger.py to flask_swagger.pyc
  byte-compiling /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages/build_swagger_spec.py to build_swagger_spec.pyc
  writing byte-compilation script '/tmp/tmpsSFkXg.py'
  /usr/bin/python -O /tmp/tmpsSFkXg.py
  removing /tmp/tmpsSFkXg.py
  running install_egg_info
  running egg_info
  writing requirements to flask_swagger.egg-info/requires.txt
  writing flask_swagger.egg-info/PKG-INFO
  writing top-level names to flask_swagger.egg-info/top_level.txt
  writing dependency_links to flask_swagger.egg-info/dependency_links.txt
  writing entry points to flask_swagger.egg-info/entry_points.txt
  writing pbr to flask_swagger.egg-info/pbr.json
  reading manifest file 'flask_swagger.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  writing manifest file 'flask_swagger.egg-info/SOURCES.txt'
  Copying flask_swagger.egg-info to /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info
  running install_scripts
  Installing flaskswagger script to /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/bin
  writing list of installed files to 'INSTALLED_FILES'
- /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD/flask-swagger-0.2.11
  /usr/lib/rpm/sepdebugcrcfix: Updated 0 CRC32s, 0 CRC32s did match.
  find: 'debug': No such file or directory
- /usr/lib/rpm/check-buildroot
- /usr/lib/rpm/brp-compress
- /usr/lib/rpm/brp-strip-static-archive /usr/bin/strip
- /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
  Bytecompiling .py files below /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64/usr/lib/python2.7 using /usr/bin/python2.7
- /usr/lib/rpm/brp-python-hardlink
- /usr/lib/rpm/redhat/brp-java-repack-jars
  Processing files: flask-swagger-0.2.11-1.noarch
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/PKG-INFO
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/SOURCES.txt
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/dependency_links.txt
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/entry_points.txt
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/pbr.json
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/requires.txt
  warning: File listed twice: /usr/lib/python2.7/site-packages/flask_swagger-0.2.11-py2.7.egg-info/top_level.txt
  Provides: flask-swagger = 0.2.11-1
  Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
  Requires: /usr/bin/python python(abi) = 2.7
  Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64
  Wrote: /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/SRPMS/flask-swagger-0.2.11-1.src.rpm
  Wrote: /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/RPMS/noarch/flask-swagger-0.2.11-1.noarch.rpm
  Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.1ypYPQ
- umask 022
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- cd flask-swagger-0.2.11
- rm -rf /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILDROOT/flask-swagger-0.2.11-1.x86_64
- exit 0
  Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.2PFRUb
- umask 022
- cd /home/krasmussen/Desktop/flask-swagger/build/bdist.linux-x86_64/rpm/BUILD
- rm -rf flask-swagger-0.2.11
- exit 0
  moving build/bdist.linux-x86_64/rpm/SRPMS/flask-swagger-0.2.11-1.src.rpm -> dist
  moving build/bdist.linux-x86_64/rpm/RPMS/noarch/flask-swagger-0.2.11-1.noarch.rpm -> dist
  [krasmussen@kras-desktop flask-swagger]$ ls -alh ./dist/flask-swagger-0.2.11-1.noarch.rpm 
  -rw-rw-r--. 1 krasmussen krasmussen 21K Nov 10 14:03 ./dist/flask-swagger-0.2.11-1.noarch.rpm
  [krasmussen@kras-desktop flask-swagger]$ sudo yum -y install ./dist/flask-swagger-0.2.11-1.noarch.rpm 
  Yum command has been deprecated, redirecting to '/usr/bin/dnf -y install ./dist/flask-swagger-0.2.11-1.noarch.rpm'.
  See 'man dnf' and 'man yum2dnf' for more information.
  To transfer transaction metadata from yum to DNF, run:
  'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'

Last metadata expiration check performed 0:26:15 ago on Tue Nov 10 13:45:14 2015.
# Dependencies resolved.
#  Package                                                     Arch                                                 Version                                                   Repository                                                  Size

Installing:
 flask-swagger                                               noarch                                               0.2.11-1                                                  @commandline                                                20 k
# Transaction Summary

Install  1 Package

Total size: 20 k
Installed size: 21 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Installing  : flask-swagger-0.2.11-1.noarch                                                                                                                                                                                            1/1 
  Verifying   : flask-swagger-0.2.11-1.noarch                                                                                                                                                                                            1/1 

Installed:
  flask-swagger.noarch 0.2.11-1                                                                                                                                                                                                              

Complete!
[krasmussen@kras-desktop flask-swagger]$ cd ~
[krasmussen@kras-desktop ~]$ python
Python 2.7.10 (default, Sep 24 2015, 17:50:09) 
[GCC 5.1.1 20150618 (Red Hat 5.1.1-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > from flask_swagger import swagger
