### PR TITLE
Fix support for static methods in a MethodViews

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -136,7 +136,7 @@ def swagger(app, process_doc=_sanitize, template=None):
         for verb in rule.methods.difference(ignore_verbs):
             if hasattr(endpoint, 'methods') and verb in endpoint.methods:
                 verb = verb.lower()
-                methods[verb] = endpoint.view_class.__dict__.get(verb)
+                methods[verb] = getattr(endpoint.view_class, verb)
             else:
                 methods[verb.lower()] = endpoint
         operations = dict()


### PR DESCRIPTION
Enable defining methods as @staticmethod. Example:

``` python
class UserAPI(MethodView):
    @staticmethod
    def get(self, team_id):
        """
        Get a list of users
        ---
        tags:
          - users
        responses:
          200:
            description: Returns a list of users
        """
        return []
```
