### PR TITLE
Fix regex to catch rules without specific types

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -174,7 +174,7 @@ def swagger(app, process_doc=_sanitize, template=None):
 
         if len(operations):
             rule = str(rule)
-            for arg in re.findall('(<(.*?\:)?(.*?)>)', rule):
+            for arg in re.findall('(<([^<>]*:)?([^<>]*)>)', rule):
                 rule = rule.replace(arg[0], '{%s}' % arg[2])
             paths[rule].update(operations)
     return output


### PR DESCRIPTION
Currently flask-swagger does not support paths with no **types**
bad

```
@route('/<param>/<another>')
```

good

```
@route('/<string:param>/<string:another>')
```

The problem explained here: https://regex101.com/r/iL3jK2/3

Solution explained here: https://regex101.com/r/gZ2rV3/4

This PR fixes the problem!
