### PR TITLE
improve the compatibility for python 3

### DIFF
--- a/build_swagger_spec.py
+++ b/build_swagger_spec.py
@@ -23,7 +23,7 @@ def run():
     else:
         spec = swagger(app)
     if args.out_dir is None:
-        print json.dumps(spec, indent=4)
+        print(json.dumps(spec, indent=4))
     else:
         with open("%s/swagger.json" % args.out_dir, 'w') as f:
             f.write(json.dumps(spec, indent=4))

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -118,9 +118,9 @@ def swagger(app, process_doc=_sanitize, template=None):
     if template is not None:
         output.update(template)
         # check for template provided paths and definitions
-        for k,v in output.get('paths',{}).iteritems():
+        for k,v in output.get('paths',{}).items():
            paths[k] = v
-        for k,v in output.get('definitions',{}).iteritems():
+        for k,v in output.get('definitions',{}).items():
            definitions[k] = v
     output["paths"] = paths
     output["definitions"] = definitions

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README') as file:
     long_description = file.read()
 
 setup(name='flask-swagger',
-      version='0.2.11',
+      version='0.2.12-dev',
       url='https://github.com/gangverk/flask-swagger',
       description='Extract swagger specs from your flask project',
       author='Atli Thorbjornsson',
@@ -15,6 +15,16 @@ setup(name='flask-swagger',
       py_modules=['flask_swagger', 'build_swagger_spec'],
       long_description=long_description,
       install_requires=['Flask>=0.10', 'PyYAML>=3.0'],
+      classifiers=[
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+      ],
       entry_points = """
       [console_scripts]
       flaskswagger = build_swagger_spec:run


### PR DESCRIPTION
For python3 (I was using python 3.4), there are two cases as follows that flask-swagger throws exceptions. This commit is to fix it.
- python code:   swagger(app, template=a_template)
- command line:   flaskswagger -h
