### PR TITLE
Swagger from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# vim swap files
+.*.sw?

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# vim swap files
-.*.sw?

--- a/README.md
+++ b/README.md
@@ -72,6 +72,79 @@ In order to support inline definition of [Schema ](https://github.com/swagger-ap
 
 [Schema ](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) objects can be defined in a definitions section within the docstrings (see group object above) or within responses or parameters (see user object above). We also support schema objects nested within the properties of other [Schema ](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject) objects. An example is shown above with the address property of User.
 
+If you don't like to put YAML on docstrings you can put the same content in an external file.
+
+#### file.yml
+```yaml
+Create a new user
+---
+tags:
+  - users
+definitions:
+  - schema:
+      id: Group
+      properties:
+        name:
+         type: string
+         description: the group's name
+parameters:
+  - in: body
+    name: body
+    schema:
+      id: User
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          description: email for user
+        name:
+          type: string
+          description: name for user
+        address:
+          description: address for user
+          schema:
+            id: Address
+            properties:
+              street:
+                type: string
+              state:
+                type: string
+              country:
+                type: string
+              postalcode:
+                type: string
+        groups:
+          type: array
+          description: list of groups
+          items:
+            $ref: "#/definitions/Group"
+responses:
+  201:
+    description: User created
+```
+
+and point to it in your docstring.
+
+```python
+class UserAPI(MethodView):
+
+    def post(self):
+        """
+        Create a new user
+
+        blah blah
+
+        swagger_from_file: path/to/file.yml
+
+        blah blah
+        """
+        return {}
+```
+
+Note that you can replace `swagger_from_file` by another keyword. Supply your chosen keyword as an argument to swagger. 
+
 
 To expose your Swagger specification to the world you provide a Flask route that does something along these lines
 
@@ -134,3 +207,9 @@ Flask-swagger builds on ideas and code from [flask-sillywalk](https://github.com
 Notable forks
 
 [Flasgger](https://github.com/rochacbruno/flasgger)
+
+### TODO
+
+- flake8
+- tests
+- add argument to build_swagger_spec

--- a/README.md
+++ b/README.md
@@ -207,9 +207,3 @@ Flask-swagger builds on ideas and code from [flask-sillywalk](https://github.com
 Notable forks
 
 [Flasgger](https://github.com/rochacbruno/flasgger)
-
-### TODO
-
-- flake8
-- tests
-- add argument to build_swagger_spec

--- a/examples/example.py
+++ b/examples/example.py
@@ -47,6 +47,14 @@ class UserAPI(MethodView):
         """
         return {}
 
+    def put(self, user_id):
+        """
+        Update a user
+
+        swagger_from_file: user_put.yml
+        """
+        return {}
+
 
 @app.after_request
 def after_request(response):

--- a/examples/example.py
+++ b/examples/example.py
@@ -152,7 +152,7 @@ def hello():
 
 @app.route("/spec")
 def spec():
-    return jsonify(swagger(app))
+    return jsonify(swagger(app, from_file_keyword='swagger_from_file'))
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/examples/user_put.yml
+++ b/examples/user_put.yml
@@ -1,0 +1,22 @@
+Update a user
+---
+tags:
+  - users
+parameters:
+  - in: body
+    name: body
+    schema:
+      id: User
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          description: email for user
+        name:
+          type: string
+          description: name for user
+responses:
+  204:
+    description: User updated

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -48,11 +48,12 @@ def _parse_docstring(obj, process_doc, from_file_keyword):
     first_line, other_lines, swag = None, None, None
     full_doc = inspect.getdoc(obj)
     if full_doc:
-        from_file = _find_from_file(full_doc, from_file_keyword)
-        if from_file:
-            full_doc_from_file = _doc_from_file(from_file)
-            if full_doc_from_file:
-                full_doc = full_doc_from_file
+        if from_file_keyword is not None:
+            from_file = _find_from_file(full_doc, from_file_keyword)
+            if from_file:
+                full_doc_from_file = _doc_from_file(from_file)
+                if full_doc_from_file:
+                    full_doc = full_doc_from_file
         line_feed = full_doc.find('\n')
         if line_feed != -1:
             first_line = process_doc(full_doc[:line_feed])
@@ -121,7 +122,7 @@ def _extract_definitions(alist, level=None):
 
 
 def swagger(app, prefix=None, process_doc=_sanitize,
-            from_file_keyword='swagger_from_file', template=None):
+            from_file_keyword=None, template=None):
     """
     Call this from an @app.route method like this
     @app.route('/spec.json')

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -17,10 +17,42 @@ def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
 
 
-def _parse_docstring(obj, process_doc):
+def _find_from_file(full_doc, from_file_keyword):
+    """
+    Finds a line in <full_doc> like
+
+        <from_file_keyword> <colon> <path>
+
+    and return path
+    """
+    path = None
+
+    for line in full_doc.splitlines():
+        if from_file_keyword in line:
+            parts = line.strip().split(':')
+            if len(parts) == 2 and parts[0].strip() == from_file_keyword:
+                path = parts[1].strip()
+                break
+
+    return path
+
+
+def _doc_from_file(path):
+    doc = None
+    with open(path) as f:
+        doc = f.read()
+    return doc
+
+
+def _parse_docstring(obj, process_doc, from_file_keyword):
     first_line, other_lines, swag = None, None, None
     full_doc = inspect.getdoc(obj)
     if full_doc:
+        from_file = _find_from_file(full_doc, from_file_keyword)
+        if from_file:
+            full_doc_from_file = _doc_from_file(from_file)
+            if full_doc_from_file:
+                full_doc = full_doc_from_file
         line_feed = full_doc.find('\n')
         if line_feed != -1:
             first_line = process_doc(full_doc[:line_feed])
@@ -88,7 +120,8 @@ def _extract_definitions(alist, level=None):
     return defs
 
 
-def swagger(app, prefix=None, process_doc=_sanitize, template=None):
+def swagger(app, prefix=None, process_doc=_sanitize,
+            from_file_keyword='swagger_from_file', template=None):
     """
     Call this from an @app.route method like this
     @app.route('/spec.json')
@@ -104,6 +137,7 @@ def swagger(app, prefix=None, process_doc=_sanitize, template=None):
 
     Keyword arguments:
     process_doc -- text sanitization method, the default simply replaces \n with <br>
+    from_file_keyword -- how to specify a file to load doc from
     template -- The spec to start with and update as flask-swagger finds paths.
     """
     output = {
@@ -143,7 +177,8 @@ def swagger(app, prefix=None, process_doc=_sanitize, template=None):
                 methods[verb.lower()] = endpoint
         operations = dict()
         for verb, method in methods.items():
-            summary, description, swag = _parse_docstring(method, process_doc)
+            summary, description, swag = _parse_docstring(method, process_doc,
+                                                          from_file_keyword)
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)


### PR DESCRIPTION
Hi,

This is a proposal to decode a special line in a docstring `swagger_from_file: path`.

I think it could be useful sometimes to take the yaml swagger spec out of the docstring:
- if you have other things to say in the docstring,
- if it's easier to edit yaml code from a .yml file.

In the pull request you'll find besides flask_swagger.py a modified example and README.md

Please criticize as needed.
Thanks.
