### PR TITLE
Don't assume method verbs are View functions

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -171,11 +171,13 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         endpoint = app.view_functions[rule.endpoint]
         methods = dict()
         for verb in rule.methods.difference(ignore_verbs):
-            if hasattr(endpoint, 'methods') and verb in endpoint.methods and hasattr(endpoint.view_class, verb.lower()):
-                verb = verb.lower()
+            verb = verb.lower()
+            if hasattr(endpoint, 'methods') \
+                    and verb in map(lambda m: m.lower(), endpoint.methods) \
+                    and hasattr(endpoint.view_class, verb):
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:
-                methods[verb.lower()] = endpoint
+                methods[verb] = endpoint
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -171,7 +171,7 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         endpoint = app.view_functions[rule.endpoint]
         methods = dict()
         for verb in rule.methods.difference(ignore_verbs):
-            if hasattr(endpoint, 'methods') and verb in endpoint.methods:
+            if hasattr(endpoint, 'methods') and verb in endpoint.methods and hasattr(endpoint.view_class, verb.lower()):
                 verb = verb.lower()
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:


### PR DESCRIPTION
When iterating through the app's endpoints, we're assuming the View instance has methods named `get`, `post`, etc for each verb in in `View`'s `methods = ['GET', 'POST']` attribute.  However this is not a requirement for implementations of `flask.views.View`.

For example, if I added a url rule with:
```
app.add_url_rule('/someview', view_func=SomeView.as_view('some_view', **kwargs))
```
the `SomeView` class is obligated to have a declaration of `methods = [...]`, but not functions named `get`, `post`, `put`, `delete`, or anything which appears in the list.  Flask swagger is assuming those functions exist in the view, and crashes on startup when it tries to access them.  This changes checks for their existence before accessing them.