### PR TITLE
Adds support for template yml files in docstring

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -49,9 +49,32 @@ class UserAPI(MethodView):
 
     def put(self, user_id):
         """
-        Update a user
+        Update a user, this summary stays
 
         swagger_from_file: user_put.yml
+
+        ---
+        tags:
+          - user_update
+        parameters:
+          - name: filename
+            in: formData
+            description: filename. this overrides what's in the .yml file
+            required: false
+            type: string
+          - name: username
+            in: formData
+            description: username
+            required: false
+            type: file
+          - name: password
+            in: formData
+            description: password
+            required: false
+            type: file
+        responses:
+          200:
+            description: this description stays
         """
         return {}
 

--- a/examples/user_put.yml
+++ b/examples/user_put.yml
@@ -1,4 +1,4 @@
-Update a user
+Update a user in yml
 ---
 tags:
   - users
@@ -17,6 +17,11 @@ parameters:
         name:
           type: string
           description: name for user
+  - name: filename
+    in: formData
+    description: filename of the yaml or python script used for training. This is not used as there's a filename already.
+    required: true
+    type: string
 responses:
   204:
     description: User updated

--- a/examples/user_put.yml
+++ b/examples/user_put.yml
@@ -1,4 +1,4 @@
-Update a user in yml
+Update a user from yml. This is not used.
 ---
 tags:
   - users

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -65,7 +65,6 @@ def _merge_swag(swag, doc_swag):
         # for dicts, we'll add doc_swag to our swag if there's a `name` val
         # that's not in any of the swag dicts
         elif swag and isinstance(swag[0], dict):
-            # grab all the names of the dict objs
             swag_names = []
             for item in swag:
                 name = [val for key, val in item.items() if key == 'name']


### PR DESCRIPTION
Fixes https://github.com/gangverk/flask-swagger/issues/39

This converts any included `yml` file into a template that then gets included in docstrings if not overridden by what's already in the docstring.

It assumes for lists of dicts (like in the case of multiple `parameters` values) that the dicts are unique by their `name` attribute, in accordance with the swagger specs.

Any comments are welcome!

The new `put` doc:

```
"put": {
        "description": "<br/>",
        "parameters": [
          {
            "description": "filename. this overrides what's in the .yml file",
            "in": "formData",
            "name": "filename",
            "required": false,
            "type": "string"
          },
          {
            "description": "username",
            "in": "formData",
            "name": "username",
            "required": false,
            "type": "file"
          },
          {
            "description": "password",
            "in": "formData",
            "name": "password",
            "required": false,
            "type": "file"
          },
          {
            "in": "body",
            "name": "body",
            "schema": {
              "$ref": "#/definitions/User"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "this description stays"
          },
          "204": {
            "description": "User updated"
          }
        },
        "summary": "Update a user, this summary stays",
        "tags": [
          "user_update"
        ]
      }
```

The `merge` function is kinda complicated so I added a bunch of comments throughout explaining how the merging happens!

Also sorry about the weird branch name, messed that up accidentally 😛 