### PR TITLE
base_path parameter and relative pathes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ def spec():
     base_path = os.path.join(app.root_path, 'docs')
     return jsonify(swagger(app), from_file_keyword="swagger_from_file", base_path=base_path)
 ```
-and use relative pathes:
+and use relative paths:
 ```
 @app.route('/test', methods=['POST'])
 def login():

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# flask-swagger
+# flask-swagger (fork)
 A Swagger 2.0 spec extractor for Flask
+
+Using this fork you can now specify base path for yml files:
+```
+app = Flask(__name__)
+
+@app.route("/spec")
+def spec():
+    base_path = os.path.join(app.root_path, 'docs')
+    return jsonify(swagger(app), from_file_keyword="swagger_from_file", base_path=base_path)
+```
+and use relative pathes:
+```
+@app.route('/test', methods=['POST'])
+def login():
+    """
+    swagger_from_file: test.yml
+    """
+```
 
 Install:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# flask-swagger (fork)
+# flask-swagger
 A Swagger 2.0 spec extractor for Flask
 
-Using this fork you can now specify base path for yml files:
+You can now specify base path for yml files:
 ```
 app = Flask(__name__)
 

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -173,8 +173,8 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         endpoint = app.view_functions[rule.endpoint]
         methods = dict()
         for verb in rule.methods.difference(ignore_verbs):
+            verb = verb.lower()
             if hasattr(endpoint, 'methods') and verb in endpoint.methods:
-                verb = verb.lower()
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:
                 methods[verb.lower()] = endpoint

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -182,6 +182,12 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,
                                                           from_file_keyword)
+            if hasattr(method, 'summary'):
+                summary = method.summary
+            if hasattr(method, 'description'):
+                description = method.description
+            if hasattr(method, 'swag'):
+                swag = method.swag
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -181,17 +181,7 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,
-<<<<<<< HEAD
                                                           from_file_keyword, base_path)
-=======
-                                                          from_file_keyword)
-            if hasattr(method, 'summary'):
-                summary = method.summary
-            if hasattr(method, 'description'):
-                description = method.description
-            if hasattr(method, 'swag'):
-                swag = method.swag
->>>>>>> f1dbf918d9903a588eed3cce2a87eeccc9f8cc0e
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -174,7 +174,9 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         methods = dict()
         for verb in rule.methods.difference(ignore_verbs):
             verb = verb.lower()
-            if hasattr(endpoint, 'methods') and verb in endpoint.methods:
+            if hasattr(endpoint, 'methods') \
+                    and verb in map(lambda m: m.lower(), endpoint.methods) \	
+                    and hasattr(endpoint.view_class, verb):
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:
                 methods[verb] = endpoint

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -5,10 +5,12 @@ An endpoint that traverses all restful endpoints producing a swagger 2.0 schema
 If a swagger yaml description is found in the docstrings for an endpoint
 we add the endpoint to swagger specification output
 
+- Added basic_path parameter
 """
 import inspect
 import yaml
 import re
+import os
 
 from collections import defaultdict
 
@@ -17,7 +19,7 @@ def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
 
 
-def _find_from_file(full_doc, from_file_keyword):
+def _find_from_file(full_doc, from_file_keyword, basic_path):
     """
     Finds a line in <full_doc> like
 
@@ -33,7 +35,7 @@ def _find_from_file(full_doc, from_file_keyword):
             if len(parts) == 2 and parts[0].strip() == from_file_keyword:
                 path = parts[1].strip()
                 break
-
+    path = path if not path else os.path.join(basic_path, path)
     return path
 
 
@@ -44,12 +46,12 @@ def _doc_from_file(path):
     return doc
 
 
-def _parse_docstring(obj, process_doc, from_file_keyword):
+def _parse_docstring(obj, process_doc, from_file_keyword, basic_path):
     first_line, other_lines, swag = None, None, None
     full_doc = inspect.getdoc(obj)
     if full_doc:
         if from_file_keyword is not None:
-            from_file = _find_from_file(full_doc, from_file_keyword)
+            from_file = _find_from_file(full_doc, from_file_keyword, basic_path)
             if from_file:
                 full_doc_from_file = _doc_from_file(from_file)
                 if full_doc_from_file:
@@ -122,7 +124,7 @@ def _extract_definitions(alist, level=None):
 
 
 def swagger(app, prefix=None, process_doc=_sanitize,
-            from_file_keyword=None, template=None):
+            from_file_keyword=None, template=None, basic_path=""):
     """
     Call this from an @app.route method like this
     @app.route('/spec.json')
@@ -171,17 +173,15 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         endpoint = app.view_functions[rule.endpoint]
         methods = dict()
         for verb in rule.methods.difference(ignore_verbs):
-            verb = verb.lower()
-            if hasattr(endpoint, 'methods') \
-                    and verb in map(lambda m: m.lower(), endpoint.methods) \
-                    and hasattr(endpoint.view_class, verb):
+            if hasattr(endpoint, 'methods') and verb in endpoint.methods:
+                verb = verb.lower()
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:
-                methods[verb] = endpoint
+                methods[verb.lower()] = endpoint
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,
-                                                          from_file_keyword)
+                                                          from_file_keyword, basic_path)
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -177,7 +177,7 @@ def swagger(app, prefix=None, process_doc=_sanitize,
             if hasattr(endpoint, 'methods') and verb in endpoint.methods:
                 methods[verb] = getattr(endpoint.view_class, verb)
             else:
-                methods[verb.lower()] = endpoint
+                methods[verb] = endpoint
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -19,7 +19,7 @@ def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
 
 
-def _find_from_file(full_doc, from_file_keyword, basic_path):
+def _find_from_file(full_doc, from_file_keyword, base_path):
     """
     Finds a line in <full_doc> like
 
@@ -35,7 +35,7 @@ def _find_from_file(full_doc, from_file_keyword, basic_path):
             if len(parts) == 2 and parts[0].strip() == from_file_keyword:
                 path = parts[1].strip()
                 break
-    path = path if not path else os.path.join(basic_path, path)
+    path = path if not path else os.path.join(base_path, path)
     return path
 
 
@@ -46,12 +46,12 @@ def _doc_from_file(path):
     return doc
 
 
-def _parse_docstring(obj, process_doc, from_file_keyword, basic_path):
+def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
     first_line, other_lines, swag = None, None, None
     full_doc = inspect.getdoc(obj)
     if full_doc:
         if from_file_keyword is not None:
-            from_file = _find_from_file(full_doc, from_file_keyword, basic_path)
+            from_file = _find_from_file(full_doc, from_file_keyword, base_path)
             if from_file:
                 full_doc_from_file = _doc_from_file(from_file)
                 if full_doc_from_file:
@@ -124,7 +124,7 @@ def _extract_definitions(alist, level=None):
 
 
 def swagger(app, prefix=None, process_doc=_sanitize,
-            from_file_keyword=None, template=None, basic_path=""):
+            from_file_keyword=None, template=None, base_path=""):
     """
     Call this from an @app.route method like this
     @app.route('/spec.json')
@@ -181,7 +181,7 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,
-                                                          from_file_keyword, basic_path)
+                                                          from_file_keyword, base_path)
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)


### PR DESCRIPTION
You can now specify base path for yml files:
```
app = Flask(__name__)

@app.route("/spec")
def spec():
    base_path = os.path.join(app.root_path, 'docs')
    return jsonify(swagger(app), from_file_keyword="swagger_from_file", base_path=base_path)
```
and use relative pathes:
```
@app.route('/test', methods=['POST'])
def login():
    """
    swagger_from_file: test.yml
    """
```