### PR TITLE
Upgrade PyYAML to 5.1

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -60,7 +60,7 @@ def _parse_docstring(obj, process_doc, from_file_keyword):
             yaml_sep = full_doc[line_feed+1:].find('---')
             if yaml_sep != -1:
                 other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
-                swag = yaml.load(full_doc[line_feed+yaml_sep:])
+                swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
             else:
                 other_lines = process_doc(full_doc[line_feed+1:])
         else:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='flask-swagger',
       license='MIT',
       py_modules=['flask_swagger', 'build_swagger_spec'],
       long_description=long_description,
-      install_requires=['Flask>=0.10', 'PyYAML>=3.0'],
+      install_requires=['Flask>=0.10', 'PyYAML>=5.1'],
       classifiers=[
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',


### PR DESCRIPTION
`yaml.load` is deprecated on PyYAML 5.1.

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation