### PR TITLE
Avoid running twice from CLI

### DIFF
--- a/build_swagger_spec.py
+++ b/build_swagger_spec.py
@@ -50,5 +50,6 @@ def run():
             f.write(json.dumps(spec, indent=4))
             f.close()
 
-run()
 
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
When running `flaskswagger`, the `run()` function would be invoked twice: One from the entrypoint and another by just importing `build_swagger_spec`.

This ensures the spec is only dumped once to stdout.