### PR TITLE
Replace deprecated load() with resolve()

### DIFF
--- a/build_swagger_spec.py
+++ b/build_swagger_spec.py
@@ -19,7 +19,7 @@ parser.add_argument('--version', default=None, help='Specify a spec version')
 args = parser.parse_args()
 
 def run():
-    app = pkg_resources.EntryPoint.parse("x=%s" % args.app).load(False)
+    app = pkg_resources.EntryPoint.parse("x=%s" % args.app).resolve()
 
     # load the base template
     template = None


### PR DESCRIPTION
This was raising a DeprecationWarning in python 3.7+:

`PkgResourcesDeprecationWarning: Parameters to load are deprecated. Call .resolve and .require separately.`