### PR TITLE
Provide context for errors

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -8,12 +8,14 @@ we add the endpoint to swagger specification output
 - Added basic_path parameter
 """
 import inspect
+import logging
 import yaml
 import re
 import os
 
 from collections import defaultdict
 
+logger = logging.getLogger(__name__)
 
 def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
@@ -47,27 +49,30 @@ def _doc_from_file(path):
 
 
 def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
-    first_line, other_lines, swag = None, None, None
-    full_doc = inspect.getdoc(obj)
-    if full_doc:
-        if from_file_keyword is not None:
-            from_file = _find_from_file(full_doc, from_file_keyword, base_path)
-            if from_file:
-                full_doc_from_file = _doc_from_file(from_file)
-                if full_doc_from_file:
-                    full_doc = full_doc_from_file
-        line_feed = full_doc.find('\n')
-        if line_feed != -1:
-            first_line = process_doc(full_doc[:line_feed])
-            yaml_sep = full_doc[line_feed+1:].find('---')
-            if yaml_sep != -1:
-                other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
-                swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
+    try:
+        first_line, other_lines, swag = None, None, None
+        full_doc = inspect.getdoc(obj)
+        if full_doc:
+            if from_file_keyword is not None:
+                from_file = _find_from_file(full_doc, from_file_keyword, base_path)
+                if from_file:
+                    full_doc_from_file = _doc_from_file(from_file)
+                    if full_doc_from_file:
+                        full_doc = full_doc_from_file
+            line_feed = full_doc.find('\n')
+            if line_feed != -1:
+                first_line = process_doc(full_doc[:line_feed])
+                yaml_sep = full_doc[line_feed+1:].find('---')
+                if yaml_sep != -1:
+                    other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
+                    swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
+                else:
+                    other_lines = process_doc(full_doc[line_feed+1:])
             else:
-                other_lines = process_doc(full_doc[line_feed+1:])
-        else:
-            first_line = full_doc
-    return first_line, other_lines, swag
+                first_line = full_doc
+        return first_line, other_lines, swag
+    except Exception as e:
+        logger.error("Failed to parse docstring for %s: %s", obj, e)
 
 
 def _extract_definitions(alist, level=None):

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -73,6 +73,7 @@ def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
         return first_line, other_lines, swag
     except Exception as e:
         logger.error("Failed to parse docstring for %s: %s", obj, e)
+        raise
 
 
 def _extract_definitions(alist, level=None):


### PR DESCRIPTION
This PR adds some logging so that errors in the YAML in a docstring give some indication of which method caused the problem.  Several times now I've gone over a large codebase adding swagger docstrings then tried to view the documentation, only to find that there is an error - somewhere.  The YAML parser will tell you which line of a docstring the error happened on, and might tell you what the offending content was, and that might be enough to find the error.  Or it might not.  This logs which object the docstring appeared on.