### PR TITLE
Embedded plantuml diagrams in docstrings

### DIFF
--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -66,8 +66,9 @@ def _parse_docstring(obj, process_doc, from_file_keyword, base_path, app):
                 first_line = process_doc(full_doc[:line_feed])
                 yaml_sep = full_doc[line_feed+1:].find('---')
                 if yaml_sep != -1:
-                    other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
+                    other_lines = full_doc[line_feed+1:line_feed+yaml_sep]
                     other_lines = generate_plantuml(other_lines, app)
+                    other_lines = process_doc(other_lines)
                     swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
                 else:
                     other_lines = process_doc(full_doc[line_feed+1:])

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -15,6 +15,8 @@ import os
 
 from collections import defaultdict
 
+from plantuml_docs import generate_plantuml
+
 logger = logging.getLogger(__name__)
 
 def _sanitize(comment):
@@ -65,6 +67,7 @@ def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
                 yaml_sep = full_doc[line_feed+1:].find('---')
                 if yaml_sep != -1:
                     other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
+                    other_lines = generate_plantuml(other_lines)
                     swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
                 else:
                     other_lines = process_doc(full_doc[line_feed+1:])
@@ -129,7 +132,8 @@ def _extract_definitions(alist, level=None):
 
 
 def swagger(app, prefix=None, process_doc=_sanitize,
-            from_file_keyword=None, template=None, base_path=""):
+            from_file_keyword=None, template=None, base_path="",
+            title="Cool product name", version="0.0.0", description=""):
     """
     Call this from an @app.route method like this
     @app.route('/spec.json')
@@ -151,8 +155,9 @@ def swagger(app, prefix=None, process_doc=_sanitize,
     output = {
         "swagger": "2.0",
         "info": {
-            "version": "0.0.0",
-            "title": "Cool product name",
+            "version": version,
+            "title": title,
+            "description": generate_plantuml(description)
         }
     }
     paths = defaultdict(dict)

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -8,12 +8,14 @@ we add the endpoint to swagger specification output
 - Added basic_path parameter
 """
 import inspect
+import logging
 import yaml
 import re
 import os
 
 from collections import defaultdict
 
+logger = logging.getLogger(__name__)
 
 def _sanitize(comment):
     return comment.replace('\n', '<br/>') if comment else comment
@@ -47,27 +49,30 @@ def _doc_from_file(path):
 
 
 def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
-    first_line, other_lines, swag = None, None, None
-    full_doc = inspect.getdoc(obj)
-    if full_doc:
-        if from_file_keyword is not None:
-            from_file = _find_from_file(full_doc, from_file_keyword, base_path)
-            if from_file:
-                full_doc_from_file = _doc_from_file(from_file)
-                if full_doc_from_file:
-                    full_doc = full_doc_from_file
-        line_feed = full_doc.find('\n')
-        if line_feed != -1:
-            first_line = process_doc(full_doc[:line_feed])
-            yaml_sep = full_doc[line_feed+1:].find('---')
-            if yaml_sep != -1:
-                other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
-                swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
+    try:
+        first_line, other_lines, swag = None, None, None
+        full_doc = inspect.getdoc(obj)
+        if full_doc:
+            if from_file_keyword is not None:
+                from_file = _find_from_file(full_doc, from_file_keyword, base_path)
+                if from_file:
+                    full_doc_from_file = _doc_from_file(from_file)
+                    if full_doc_from_file:
+                        full_doc = full_doc_from_file
+            line_feed = full_doc.find('\n')
+            if line_feed != -1:
+                first_line = process_doc(full_doc[:line_feed])
+                yaml_sep = full_doc[line_feed+1:].find('---')
+                if yaml_sep != -1:
+                    other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
+                    swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
+                else:
+                    other_lines = process_doc(full_doc[line_feed+1:])
             else:
-                other_lines = process_doc(full_doc[line_feed+1:])
-        else:
-            first_line = full_doc
-    return first_line, other_lines, swag
+                first_line = full_doc
+        return first_line, other_lines, swag
+    except Exception as e:
+        logger.error("Failed to parse docstring for %s: %s", obj, e)
 
 
 def _extract_definitions(alist, level=None):

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -73,6 +73,7 @@ def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
         return first_line, other_lines, swag
     except Exception as e:
         logger.error("Failed to parse docstring for %s: %s", obj, e)
+        raise
 
 
 def _extract_definitions(alist, level=None):

--- a/flask_swagger.py
+++ b/flask_swagger.py
@@ -50,7 +50,7 @@ def _doc_from_file(path):
     return doc
 
 
-def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
+def _parse_docstring(obj, process_doc, from_file_keyword, base_path, app):
     try:
         first_line, other_lines, swag = None, None, None
         full_doc = inspect.getdoc(obj)
@@ -67,7 +67,7 @@ def _parse_docstring(obj, process_doc, from_file_keyword, base_path):
                 yaml_sep = full_doc[line_feed+1:].find('---')
                 if yaml_sep != -1:
                     other_lines = process_doc(full_doc[line_feed+1:line_feed+yaml_sep])
-                    other_lines = generate_plantuml(other_lines)
+                    other_lines = generate_plantuml(other_lines, app)
                     swag = yaml.full_load(full_doc[line_feed+yaml_sep:])
                 else:
                     other_lines = process_doc(full_doc[line_feed+1:])
@@ -157,7 +157,7 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         "info": {
             "version": version,
             "title": title,
-            "description": generate_plantuml(description)
+            "description": generate_plantuml(description, app)
         }
     }
     paths = defaultdict(dict)
@@ -193,7 +193,8 @@ def swagger(app, prefix=None, process_doc=_sanitize,
         operations = dict()
         for verb, method in methods.items():
             summary, description, swag = _parse_docstring(method, process_doc,
-                                                          from_file_keyword, base_path)
+                                                          from_file_keyword, base_path,
+                                                          app)
             if swag is not None:  # we only add endpoints with swagger data in the docstrings
                 defs = swag.get('definitions', [])
                 defs = _extract_definitions(defs)

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     plantuml = None
 
-_PLANTUML_RE = re.compile("(@startuml.*?@enduml)", re.MULTILINE)
+_PLANTUML_RE = re.compile("(@startuml.*?@enduml)", re.MULTILINE|re.DOTALL)
 FLASK_SWAGGER_PLANTUML_SERVER = 'FLASK_SWAGGER_PLANTUML_SERVER'
 FLASK_SWAGGER_PLANTUML_FOLDER = 'FLASK_SWAGGER_PLANTUML_FOLDER'
 
@@ -49,7 +49,7 @@ def generate_plantuml(docstring, app):
             break
         uml = match.group(1)
         # The same UML data will produce the same filename
-        filename = hashlib.sha256(uml.encode('utf-8')).decode('utf-8') + '.png'
+        filename = hashlib.sha256(uml.encode('utf-8')).hexdigest() + '.png'
         output_file = os.path.join(folder, filename)
         try:
             image_data = server.processes(uml)

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -14,6 +14,9 @@ _PLANTUML_RE = re.compile("(@startuml.*?@enduml)", re.MULTILINE|re.DOTALL)
 FLASK_SWAGGER_PLANTUML_SERVER = 'FLASK_SWAGGER_PLANTUML_SERVER'
 FLASK_SWAGGER_PLANTUML_FOLDER = 'FLASK_SWAGGER_PLANTUML_FOLDER'
 
+def sub(string, match, replacement):
+    return string[:match.start()] + replacement + string[match.end():]
+
 def generate_plantuml(docstring, app):
     """
     Generate PlantUML diagrams from the given docstring.
@@ -57,13 +60,13 @@ def generate_plantuml(docstring, app):
             image_data = server.processes(uml)
             with open(output_file, 'wb') as file:
                 file.write(image_data)
-            docstring = match.sub(f"![{filename}][/static/{subfolder}/{filename}]")
+            docstring = sub(docstring, match, f"![{filename}][/static/{subfolder}/{filename}]")
         except plantuml.PlantUMLConnectionError as e:
-            docstring = match.sub(f"Failed to connect to the PlantUML server: {e}")
+            docstring = sub(docstring, match, f"Failed to connect to the PlantUML server: {e}")
         except plantuml.PlantUMLHTTPError as e:
-            docstring = match.sub(f"HTTP error while connection to the PlantUML server: {e}")
+            docstring = sub(docstring, match, f"HTTP error while connection to the PlantUML server: {e}")
         except plantuml.PlantUMLError as e:
-            docstring = match.sub(f"PlantUML error: {e}")
+            docstring = sub(docstring, match, f"PlantUML error: {e}")
 
     return docstring
 

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -60,7 +60,7 @@ def generate_plantuml(docstring, app):
             image_data = server.processes(uml)
             with open(output_file, 'wb') as file:
                 file.write(image_data)
-            docstring = sub(docstring, match, f'![{filename}](/static/{subfolder}/{filename}])')
+            docstring = sub(docstring, match, f'![{filename}](/static/{subfolder}/{filename})')
         except plantuml.PlantUMLConnectionError as e:
             docstring = sub(docstring, match, f"Failed to connect to the PlantUML server: {e}")
         except plantuml.PlantUMLHTTPError as e:

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -35,13 +35,9 @@ def generate_plantuml(docstring, app):
         logger.info("PlantUML not installed; not generating diagrams")
         return docstring
 
-    url=app.config.get('FLASK_SWAGGER_PLANTUML_SERVER')
-    if url:
-        logger.info("User PlantUML server %s", url)
-        server = plantuml.PlantUML(url=url)
-    else:
-        logger.info("Using default public PlantUML server")
-        server = plantuml.PlantUML()
+    url=app.config.get('FLASK_SWAGGER_PLANTUML_SERVER', 'http://www.plantuml.com/plantuml/img/')
+    logger.info("User PlantUML server %s", url)
+    server = plantuml.PlantUML(url=url)
 
     subfolder = app.config.get(FLASK_SWAGGER_PLANTUML_FOLDER, 'uml')
     folder = os.path.join(app.static_folder, subfolder)

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -38,7 +38,7 @@ def generate_plantuml(docstring, app):
         logger.info("PlantUML not installed; not generating diagrams")
         return docstring
 
-    url=app.config.get('FLASK_SWAGGER_PLANTUML_SERVER', 'http://www.plantuml.com/plantuml/img/')
+    url=app.config.get(FLASK_SWAGGER_PLANTUML_SERVER, 'http://www.plantuml.com/plantuml/img/')
     logger.info("User PlantUML server %s", url)
     server = plantuml.PlantUML(url=url)
 

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -60,7 +60,7 @@ def generate_plantuml(docstring, app):
             image_data = server.processes(uml)
             with open(output_file, 'wb') as file:
                 file.write(image_data)
-            docstring = sub(docstring, match, f'![{filename}](/static/{subfolder}/{filename})')
+            docstring = sub(docstring, match, f'![{filename}]({app.static_url_path}/{subfolder}/{filename})')
         except plantuml.PlantUMLConnectionError as e:
             docstring = sub(docstring, match, f"Failed to connect to the PlantUML server: {e}")
         except plantuml.PlantUMLHTTPError as e:

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -41,6 +41,8 @@ def generate_plantuml(docstring, app):
 
     subfolder = app.config.get(FLASK_SWAGGER_PLANTUML_FOLDER, 'uml')
     folder = os.path.join(app.static_folder, subfolder)
+    if not os.path.exists():
+        os.mkdir(folder)
     logger.info("Outputting diagrams to %s", folder)
 
     while True:

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -41,7 +41,7 @@ def generate_plantuml(docstring, app):
 
     subfolder = app.config.get(FLASK_SWAGGER_PLANTUML_FOLDER, 'uml')
     folder = os.path.join(app.static_folder, subfolder)
-    if not os.path.exists():
+    if not os.path.exists(folder):
         os.mkdir(folder)
     logger.info("Outputting diagrams to %s", folder)
 

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -60,7 +60,7 @@ def generate_plantuml(docstring, app):
             image_data = server.processes(uml)
             with open(output_file, 'wb') as file:
                 file.write(image_data)
-            docstring = sub(docstring, match, f'<img alt="{filename}" src="/static/{subfolder}/{filename}]">')
+            docstring = sub(docstring, match, f'![{filename}](/static/{subfolder}/{filename}])')
         except plantuml.PlantUMLConnectionError as e:
             docstring = sub(docstring, match, f"Failed to connect to the PlantUML server: {e}")
         except plantuml.PlantUMLHTTPError as e:

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -60,7 +60,7 @@ def generate_plantuml(docstring, app):
             image_data = server.processes(uml)
             with open(output_file, 'wb') as file:
                 file.write(image_data)
-            docstring = sub(docstring, match, f"![{filename}][/static/{subfolder}/{filename}]")
+            docstring = sub(docstring, match, f'<img alt="{filename}" src="/static/{subfolder}/{filename}]">')
         except plantuml.PlantUMLConnectionError as e:
             docstring = sub(docstring, match, f"Failed to connect to the PlantUML server: {e}")
         except plantuml.PlantUMLHTTPError as e:

--- a/plantuml_docs.py
+++ b/plantuml_docs.py
@@ -35,18 +35,18 @@ def generate_plantuml(docstring, app):
       image.
     """
     if not plantuml:
-        logger.info("PlantUML not installed; not generating diagrams")
+        logger.debug("PlantUML not installed; not generating diagrams")
         return docstring
 
     url=app.config.get(FLASK_SWAGGER_PLANTUML_SERVER, 'http://www.plantuml.com/plantuml/img/')
-    logger.info("User PlantUML server %s", url)
+    logger.debug("Using PlantUML server %s", url)
     server = plantuml.PlantUML(url=url)
 
     subfolder = app.config.get(FLASK_SWAGGER_PLANTUML_FOLDER, 'uml')
     folder = os.path.join(app.static_folder, subfolder)
     if not os.path.exists(folder):
         os.mkdir(folder)
-    logger.info("Outputting diagrams to %s", folder)
+    logger.debug("Outputting diagrams to %s", folder)
 
     while True:
         match = _PLANTUML_RE.search(docstring)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='flask-swagger',
       description='Extract swagger specs from your flask project',
       author='Atli Thorbjornsson',
       license='MIT',
-      py_modules=['flask_swagger', 'build_swagger_spec'],
+      py_modules=['flask_swagger', 'build_swagger_spec', 'plantuml_docs'],
       long_description=long_description,
       install_requires=['Flask>=0.10', 'PyYAML>=5.1'],
       classifiers=[


### PR DESCRIPTION
This PR adds an optional ability to embed plantuml diagrams in the description section of endpoint docstrings.  Example:

```
@app.route('/foo')
def foo():
    """
    # Expected sequence
    @startuml
    client -> server: /foo
    server --> client: response {id}
    client -> server: /bar/{id}
    @enduml
    """
    return 'foobar'
```

This relies on having a PlantUML server available.  By default, it uses the public server available at http://www.plantuml.com/plantuml/img/ but this can be configured by setting `FLASK_SWAGGER_PLANTUML_SERVER` in the flask app config.

The diagrams it generates go into a subdirectory of the app's static content directory.  By default this subdirectory is called `uml` but it can be configured by setting `FLASK_SWAGGER_PLANTUML_FOLDER` in the flask app config.

The diagram content is replaced with a GFM image tag.  If an error occurs while generating the image, the image content is replaced with an error message.  If the `plantuml` package is not available, swagger generation proceeds as normal.

I've also added parameters to the `swagger` method for `title`, `version` and `description`.  This is mostly so that the `description` content can be scanned for diagram content.

Currently uses some Python 3.6+ syntax.  Let me know if this is an obstacle to merging & I can fix.